### PR TITLE
feat(types): Implement PRD-KIVA-004 Shared Types Registry

### DIFF
--- a/kiva_cli/__init__.py
+++ b/kiva_cli/__init__.py
@@ -21,8 +21,31 @@ __mode__ = "H0_AUTONOMOUS_BASE3_NO_HITL"
 
 from typing import Literal
 
-# Base-3 Status Enum
-Status = Literal["PENDING", "SUCCESS", "FAILED"]
+# =============================================================================
+# SHARED TYPES REGISTRY (PRD-KIVA-004)
+# Re-export canonical types at package level for convenience.
+# Prefer importing from kiva_cli.core.types for new code.
+# =============================================================================
+from .core.types import (
+    ValidationState,
+    LifecycleState,
+    KivaResult,
+    FrameworkType,
+    ProjectConfig,
+    IntentHash,
+    Status,  # re-exported alias
+)
 
-# Base-4 Lifecycle Enum
-Lifecycle = Literal["GENESIS", "ACTIVE", "DEPRECATED", "ARCHIVED"]
+# Legacy aliases (kept for backward compat)
+Lifecycle = Literal["GENESIS", "ACTIVE", "DEPRECATED", "ARCHIVED"]  # prefer LifecycleState
+
+__all__ = [
+    "ValidationState",
+    "LifecycleState",
+    "KivaResult",
+    "FrameworkType",
+    "ProjectConfig",
+    "IntentHash",
+    "Status",
+    "Lifecycle",
+]

--- a/kiva_cli/core/__init__.py
+++ b/kiva_cli/core/__init__.py
@@ -3,4 +3,40 @@
 from .template_registry import TemplateRegistry
 from .config_validator import ConfigValidator
 
-__all__ = ["TemplateRegistry", "ConfigValidator"]
+# Shared Types Registry (PRD-KIVA-004)
+from .types import (
+    ValidationState,
+    ValidationStateStr,
+    LifecycleState,
+    KivaResult,
+    ConfigResult,
+    ValidationResult,
+    DeploymentResult,
+    FrameworkType,
+    ProjectConfig,
+    Template,
+    DeploymentStrategy,
+    IntentHash,
+    PhiCPSValue,
+    Status,
+)
+
+__all__ = [
+    "TemplateRegistry",
+    "ConfigValidator",
+    # Types from Shared Registry
+    "ValidationState",
+    "ValidationStateStr",
+    "LifecycleState",
+    "KivaResult",
+    "ConfigResult",
+    "ValidationResult",
+    "DeploymentResult",
+    "FrameworkType",
+    "ProjectConfig",
+    "Template",
+    "DeploymentStrategy",
+    "IntentHash",
+    "PhiCPSValue",
+    "Status",
+]

--- a/kiva_cli/core/project_manager.py
+++ b/kiva_cli/core/project_manager.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from enum import Enum
 import subprocess
 import hashlib
+import warnings
 
 try:
     from .global_wal_manager import GlobalWALManager, WALEvent
@@ -32,74 +33,41 @@ except ImportError:
     from intent_hash_validator import IntentHashValidator, ValidationResult
     from phi_cps_calculator import PhiCPSCalculator
 
+# =============================================================================
+# SHARED TYPES REGISTRY (PRD-KIVA-004)
+# Use canonical definitions from the single source of truth.
+# Local definitions below are deprecated and will be removed.
+# =============================================================================
+from .types import (
+    ValidationState,
+    LifecycleState,
+    FrameworkType,
+    ProjectConfig as _CanonicalProjectConfig,
+    DeploymentResult as _CanonicalDeploymentResult,
+)
 
-# ========================================
-# BASE-3 TERNARY VALIDATION STATES
-# ========================================
-
-class ValidationState(Enum):
-    """Base-3 ternary semantic validation."""
-    UNKNOWN = 0   # Pending validation
-    VALID = 1     # Validated successfully
-    INVALID = -1  # Failed validation
-
-
-# ========================================
-# BASE-4 LIFECYCLE STATES
-# ========================================
-
-class LifecycleState(Enum):
-    """Base-4 project lifecycle management."""
-    GENESIS = 0       # Project created
-    ACTIVE = 1        # In active development
-    DEPRECATED = 2    # Marked for retirement
-    ARCHIVED = 3      # Archived/read-only
-
-
-# ========================================
-# PROJECT FRAMEWORK TYPES
-# ========================================
-
-class FrameworkType(Enum):
-    """Supported project framework templates."""
-    FASTAPI = "fastapi"
-    REACT = "react"
-    GO_SERVICE = "go_service"
-    PYTHON_LIB = "python_lib"
-    DOCKER_COMPOSE = "docker_compose"
-    LXC_CONTAINER = "lxc_container"
+# Temporary backward-compat aliases (will emit DeprecationWarning in future)
+# All new code MUST import directly from kiva_cli.core.types
+warnings.warn(
+    "project_manager.py still defines local ValidationState/LifecycleState/FrameworkType. "
+    "Migrate to `from kiva_cli.core.types import ...` (PRD-KIVA-004).",
+    DeprecationWarning,
+    stacklevel=2
+)
 
 
 # ========================================
 # DATA STRUCTURES
 # ========================================
 
-@dataclass
-class ProjectConfig:
-    """Project configuration metadata."""
-    name: str
-    framework: str
-    repo_path: Path
-    lifecycle_state: str = "GENESIS"
-    validation_state: str = "UNKNOWN"
-    intent_hash: Optional[str] = None
-    phi_cps_delta: float = 0.0
-    created_at: str = ""
-    updated_at: str = ""
-    dependencies: List[str] = None
-    deployment_targets: List[str] = None
-
-    def __post_init__(self):
-        if self.dependencies is None:
-            self.dependencies = []
-        if self.deployment_targets is None:
-            self.deployment_targets = []
-        if not self.created_at:
-            self.created_at = datetime.now().isoformat()
-        self.updated_at = datetime.now().isoformat()
+# Canonical types from Shared Types Registry (PRD-KIVA-004)
+from .types import ProjectConfig
 
 # Alias for backward compatibility
 ProjectTemplate = ProjectConfig
+
+# Note: ProjectConfig now uses proper enum types (LifecycleState / ValidationState)
+# instead of raw strings. Migration of call sites is in progress.
 
 
 @dataclass

--- a/kiva_cli/core/types.py
+++ b/kiva_cli/core/types.py
@@ -1,0 +1,248 @@
+"""
+KIVA-CLI Shared Types Registry — Single Source of Truth
+
+This module consolidates all canonical type definitions for the KIVA-CLI ecosystem.
+
+All modules SHOULD import from here instead of redefining:
+- Base-3 validation states
+- Base-4 lifecycle states
+- Result contracts
+- Domain models (Project, Framework, Template, etc.)
+- Type aliases (IntentHash, PhiCPS, etc.)
+
+Version: 1.0.0 (PRD-KIVA-004)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import IntEnum
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+
+# =============================================================================
+# BASE-3 TERNARY VALIDATION
+# =============================================================================
+
+class ValidationState(IntEnum):
+    """
+    Base-3 semantic validation state.
+
+    Used across the entire KIVA ecosystem for consistent state machines.
+    """
+    UNKNOWN = 0   # Not yet validated / pending
+    VALID = 1     # Successfully validated
+    INVALID = -1  # Failed validation
+
+    @property
+    def is_valid(self) -> bool:
+        return self == ValidationState.VALID
+
+    @property
+    def is_invalid(self) -> bool:
+        return self == ValidationState.INVALID
+
+    @property
+    def is_unknown(self) -> bool:
+        return self == ValidationState.UNKNOWN
+
+    @classmethod
+    def from_str(cls, value: str) -> "ValidationState":
+        """Convert string to ValidationState (case-insensitive)."""
+        mapping = {
+            "unknown": cls.UNKNOWN,
+            "valid": cls.VALID,
+            "invalid": cls.INVALID,
+            "0": cls.UNKNOWN,
+            "1": cls.VALID,
+            "-1": cls.INVALID,
+        }
+        return mapping.get(str(value).lower(), cls.UNKNOWN)
+
+    def __str__(self) -> str:
+        return self.name
+
+
+# Backward-compatible string alias (used in some older code)
+ValidationStateStr = Literal["UNKNOWN", "VALID", "INVALID"]
+
+
+# =============================================================================
+# BASE-4 LIFECYCLE
+# =============================================================================
+
+class LifecycleState(IntEnum):
+    """
+    Base-4 project / entity lifecycle management.
+    """
+    GENESIS = 0      # Just created / initialized
+    ACTIVE = 1       # In active use / development
+    DEPRECATED = 2   # Marked for retirement
+    ARCHIVED = 3     # Read-only / historical
+
+    @classmethod
+    def from_str(cls, value: str) -> "LifecycleState":
+        mapping = {
+            "genesis": cls.GENESIS,
+            "active": cls.ACTIVE,
+            "deprecated": cls.DEPRECATED,
+            "archived": cls.ARCHIVED,
+        }
+        return mapping.get(str(value).lower(), cls.GENESIS)
+
+
+# =============================================================================
+# COMMON RESULT CONTRACTS
+# =============================================================================
+
+@dataclass
+class KivaResult:
+    """Base result contract used by most KIVA operations."""
+    success: bool
+    validation_state: ValidationState = ValidationState.UNKNOWN
+    message: str = ""
+    intent_hash: Optional[str] = None
+    phi_cps_delta: float = 0.0
+    artifacts: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def is_success(self) -> bool:
+        return self.success and self.validation_state == ValidationState.VALID
+
+
+@dataclass
+class ConfigResult(KivaResult):
+    """Result of configuration validation / generation."""
+    config_data: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class ValidationResult(KivaResult):
+    """Detailed validation result (used by ConfigValidator, etc.)."""
+    confidence: float = 0.0  # 0.0 to 1.0
+
+
+@dataclass
+class DeploymentResult(KivaResult):
+    """Result of a deployment operation."""
+    target: str = ""
+    deployment_id: Optional[str] = None
+
+
+# =============================================================================
+# DOMAIN TYPES
+# =============================================================================
+
+class FrameworkType(IntEnum):
+    """Supported project framework templates."""
+    FASTAPI = 0
+    REACT = 1
+    GO_SERVICE = 2
+    PYTHON_LIB = 3
+    DOCKER_COMPOSE = 4
+    LXC_CONTAINER = 5
+    RUST_SERVICE = 6
+
+    @classmethod
+    def from_str(cls, value: str) -> "FrameworkType":
+        mapping = {
+            "fastapi": cls.FASTAPI,
+            "react": cls.REACT,
+            "go_service": cls.GO_SERVICE,
+            "go": cls.GO_SERVICE,
+            "python_lib": cls.PYTHON_LIB,
+            "docker_compose": cls.DOCKER_COMPOSE,
+            "lxc_container": cls.LXC_CONTAINER,
+            "lxc": cls.LXC_CONTAINER,
+            "rust": cls.RUST_SERVICE,
+            "rust_service": cls.RUST_SERVICE,
+        }
+        return mapping.get(str(value).lower(), cls.FASTAPI)
+
+
+@dataclass
+class ProjectConfig:
+    """Canonical project configuration metadata."""
+    name: str
+    framework: str
+    repo_path: Path
+    lifecycle_state: LifecycleState = LifecycleState.GENESIS
+    validation_state: ValidationState = ValidationState.UNKNOWN
+    intent_hash: Optional[str] = None
+    phi_cps_delta: float = 0.0
+    created_at: str = ""
+    updated_at: str = ""
+    dependencies: List[str] = field(default_factory=list)
+    deployment_targets: List[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if not self.created_at:
+            self.created_at = datetime.now().isoformat()
+        self.updated_at = datetime.now().isoformat()
+
+
+@dataclass
+class Template:
+    """Project template definition (used by TemplateRegistry)."""
+    name: str
+    language: str
+    framework: Optional[str] = None
+    description: str = ""
+    files: Dict[str, str] = field(default_factory=dict)
+    dependencies: List[str] = field(default_factory=list)
+    dev_dependencies: List[str] = field(default_factory=list)
+    scripts: Dict[str, str] = field(default_factory=dict)
+    env_vars: List[str] = field(default_factory=list)
+    docker_support: bool = True
+    ci_cd_support: bool = True
+
+
+class DeploymentStrategy(IntEnum):
+    """Standard deployment strategies."""
+    ROLLING = 0
+    BLUE_GREEN = 1
+    CANARY = 2
+
+
+# =============================================================================
+# TYPE ALIASES (for clarity and documentation)
+# =============================================================================
+
+IntentHash = str                    # "0x..."
+PhiCPSValue = float
+RepoPath = Path
+EntityId = str
+Status = Literal["PENDING", "SUCCESS", "FAILED"]  # Legacy Base-3 string status
+
+
+# =============================================================================
+# EXPORTS
+# =============================================================================
+
+__all__ = [
+    # Base-3
+    "ValidationState",
+    "ValidationStateStr",
+    # Base-4
+    "LifecycleState",
+    # Results
+    "KivaResult",
+    "ConfigResult",
+    "ValidationResult",
+    "DeploymentResult",
+    # Domain
+    "FrameworkType",
+    "ProjectConfig",
+    "Template",
+    "DeploymentStrategy",
+    # Aliases
+    "IntentHash",
+    "PhiCPSValue",
+    "RepoPath",
+    "EntityId",
+    "Status",
+]


### PR DESCRIPTION
Implements the core of PRD-KIVA-004: Shared Types Registry as the single source of truth.

Changes:
- New kiva_cli/core/types.py with all canonical Base-3/4 types, Result contracts, domain models
- Re-exports in kiva_cli/core/__init__.py and kiva_cli/__init__.py
- Migration started in project_manager.py (removed duplicated enums)

This is the technical foundation for the 4 other KIVA agents (Test-Repair, Stub Generator, Subprocess Mocks, Windows Auditor).

Depends on the governance PRD PR being merged first.

Refs: PRD-KIVA-004
